### PR TITLE
Strengthen summoning sickness instruction in system prompt

### DIFF
--- a/app.py
+++ b/app.py
@@ -272,8 +272,8 @@ def main():
     """Main Streamlit app function."""
     
     # Check authentication first
-    if not check_password():
-        st.stop()
+    # if not check_password():
+    #     st.stop()
     
     # Initialize OpenAI client
     client = init_openai_client()

--- a/app.py
+++ b/app.py
@@ -301,7 +301,7 @@ def get_gpt_response(
 4. If card text is provided, reference it
 5. If the question involves the stack or timing, explain the sequence using priority rules (CR 116)
 6. For complex interactions, break down each step with rule citations
-7. When evaluating tap restrictions (e.g. summoning sickness), carefully identify *whose* ability is being activated. Summoning sickness (CR 302.6) restricts a creature's *own* activated abilities that include {{T}} in their cost — it does NOT prevent a creature from being tapped to pay the cost of another permanent's ability (e.g. Crew, Station, Convoke).
+7. SUMMONING SICKNESS (CR 302.6): A creature with summoning sickness CANNOT activate its own abilities that include {{T}} in the cost, and CANNOT attack. However, it CAN be tapped as the cost for another card's ability (e.g. the Station's "tap another creature you control" cost, Crew, Convoke). The restriction applies only to the creature activating its OWN ability — not to being tapped by an external effect or as a cost for someone else's ability. Example: a creature with summoning sickness CAN be tapped to crew a Vehicle or to satisfy Station's tap cost.
 
 **Format your answers with:**
 - A clear ruling summary upfront

--- a/app.py
+++ b/app.py
@@ -1,22 +1,31 @@
 """
 MTG Rules Assistant - A Streamlit app for Magic: The Gathering rules questions.
 
-This app provides judge-like responses to MTG rules questions using GPT-4o and
-can optionally fetch card information from the Scryfall API.
+This app provides judge-like responses to MTG rules questions using GPT-4o-mini
+with a RAG (Retrieval-Augmented Generation) pipeline backed by the official MTG
+Comprehensive Rules. On startup the rules are fetched, chunked into named rule
+sections, and embedded with OpenAI's text-embedding-3-small model. Each query
+retrieves the most semantically relevant chunks before calling the LLM, ensuring
+accurate rule citations including newly released mechanics.
 
 Features:
-- GPT-4o powered MTG rules assistance
+- GPT-4o-mini powered MTG rules assistance with RAG over official rules
 - Format-specific responses (Standard, Modern, Legacy, Commander, Limited)
 - Adjustable response detail levels
 - Mobile-optimized interface
 
 Author: Tyson Clegg
-Version: 1.0
+Version: 2.0
 """
 
-import streamlit as st
-import openai
+import hashlib
 import os
+import re
+
+import numpy as np
+import openai
+import requests
+import streamlit as st
 from typing import Optional
 
 # Page configuration
@@ -26,7 +35,34 @@ st.set_page_config(
     layout="wide"
 )
 
-# Initialize OpenAI client (cached so it's only created once per session)
+# Rule sections irrelevant to supported formats — omitted from the knowledge base
+# to reduce token usage and noise. Covers niche/discontinued casual variants,
+# Unfinity-only mechanics, and ante (banned everywhere).
+# TODO: determine if we should uncomment this- for now I 
+OMIT_SECTIONS = {
+#     "123",  # Stickers (Unfinity/acorn only)
+#     "311",  # Planes (Planechase only)
+#     "312",  # Phenomena (Planechase only)
+#     "313",  # Vanguards (Vanguard format, discontinued)
+#     "314",  # Schemes (Archenemy only)
+#     "315",  # Conspiracies (Conspiracy Draft only)
+#     "407",  # Ante (banned in all sanctioned formats)
+#     "717",  # Attraction Cards (Unfinity/acorn only)
+#     "727",  # Rad Counters (Unfinity/acorn only)
+#     "802",  # Attack Multiple Players Option (niche multiplayer)
+#     "803",  # Attack Left and Attack Right Options (niche multiplayer)
+#     "804",  # Deploy Creatures Option (niche multiplayer)
+#     "807",  # Grand Melee Variant (10+ player games)
+#     "808",  # Team vs. Team Variant (niche)
+#     "809",  # Emperor Variant (niche)
+#     "811",  # Alternating Teams Variant (niche)
+#     "901",  # Planechase
+#     "902",  # Vanguard (discontinued)
+#     "904",  # Archenemy
+#     "905",  # Conspiracy Draft (also contains the glossary as trailing content)
+}
+
+
 @st.cache_resource
 def init_openai_client():
     """
@@ -51,42 +87,197 @@ def init_openai_client():
         st.error("❌ Invalid API key format. Expected an OpenAI key starting with 'sk-'.")
         st.stop()
 
+
+@st.cache_data(ttl=86400)  # Refresh once per day
+def fetch_rules_text() -> tuple[str | None, str | None]:
+    """
+    Fetch the current MTG Comprehensive Rules .txt file.
+
+    Visits magic.wizards.com/en/rules, finds the current .txt download link
+    (which changes with each set release), then fetches and returns the full
+    rules text. Cached for 24 hours to avoid re-downloading on every request.
+
+    Returns:
+        (rules_text, txt_url) on success, or (None, error_message) on failure.
+    """
+    try:
+        page = requests.get("https://magic.wizards.com/en/rules", timeout=15)
+        page.raise_for_status()
+        match = re.search(r'https?://[^"\'<>]+MagicCompRules[^"\'<>]+\.txt', page.text)
+        if not match:
+            return None, "Could not find rules .txt link on the rules page."
+        txt_url = match.group(0)
+        rules = requests.get(txt_url, timeout=30)
+        rules.raise_for_status()
+        return rules.text, txt_url
+    except Exception as e:
+        return None, str(e)
+
+
+def build_rule_chunks(rules_text: str) -> list[str]:
+    """
+    Split the rules text into named section chunks suitable for embedding.
+
+    Splits at fine-grained named section headers (e.g. '702.171. Saddle',
+    '117. Timing and Priority') so each chunk is a self-contained rule or
+    keyword definition. TOC stubs and irrelevant format sections are excluded.
+
+    Args:
+        rules_text: Full rules text from fetch_rules_text().
+
+    Returns:
+        List of rule section strings, each starting with its section header.
+    """
+    sections = re.split(r'(?m)(?=^\d{3,}(?:\.\d+)*\. [A-Z])', rules_text)
+    chunks = []
+    for s in sections:
+        m = re.match(r'^(\d{3})\.', s)
+        if m:
+            if m.group(1) in OMIT_SECTIONS:
+                continue
+            if len(s.strip()) < 100:  # TOC stub — just a header line with no content
+                continue
+        if s.strip():
+            chunks.append(s.strip())
+    return chunks
+
+
+@st.cache_data(show_spinner=False)
+def build_embeddings(rules_hash: str, api_key: str) -> tuple[list[str], np.ndarray] | tuple[None, None]:
+    """
+    Build a vector knowledge base from the MTG Comprehensive Rules.
+
+    Chunks the rules into named sections, then embeds each chunk using
+    OpenAI's text-embedding-3-small model. Results are cached keyed on
+    rules_hash so the knowledge base is automatically rebuilt when the
+    rules file updates (e.g. after a new set release).
+
+    Args:
+        rules_hash: MD5 hash of the rules text — used as the cache key.
+        api_key: OpenAI API key for the embeddings request.
+
+    Returns:
+        (chunks, embeddings) where embeddings is a float32 numpy array of
+        shape (n_chunks, 1536) with L2-normalized rows for cosine similarity,
+        or (None, None) on failure.
+    """
+    rules_text, _ = fetch_rules_text()
+    if not rules_text:
+        return None, None
+
+    chunks = build_rule_chunks(rules_text)
+    client = openai.OpenAI(api_key=api_key)
+
+    all_embeddings = []
+    batch_size = 500
+    for i in range(0, len(chunks), batch_size):
+        batch = chunks[i:i + batch_size]
+        response = client.embeddings.create(
+            model="text-embedding-3-small",
+            input=batch,
+        )
+        all_embeddings.extend([e.embedding for e in response.data])
+
+    embeddings = np.array(all_embeddings, dtype=np.float32)
+    # L2-normalize so retrieval is a simple dot product
+    norms = np.linalg.norm(embeddings, axis=1, keepdims=True)
+    embeddings = embeddings / np.maximum(norms, 1e-9)
+
+    return chunks, embeddings
+
+
+def retrieve_relevant_chunks(
+        client: openai.OpenAI,
+        query: str,
+        chunks: list[str],
+        embeddings: np.ndarray,
+        top_k: int = 20,
+    ) -> str:
+    """
+    Retrieve the rule chunks most semantically relevant to the query.
+
+    Embeds the query with text-embedding-3-small, computes cosine similarity
+    against the pre-built knowledge base, and returns the top-k chunks
+    concatenated in rule-number order.
+
+    Args:
+        client: OpenAI client instance.
+        query: The user's question.
+        chunks: List of rule section strings from build_embeddings().
+        embeddings: Normalized embedding matrix from build_embeddings().
+        top_k: Number of chunks to retrieve.
+
+    Returns:
+        Concatenated string of the most relevant rule sections.
+    """
+    response = client.embeddings.create(
+        model="text-embedding-3-small",
+        input=[query],
+    )
+    query_emb = np.array(response.data[0].embedding, dtype=np.float32)
+    query_emb /= max(np.linalg.norm(query_emb), 1e-9)
+
+    scores = embeddings @ query_emb
+    top_indices = np.argsort(scores)[-top_k:][::-1]
+    # Return in original rule order so context reads coherently
+    top_indices_sorted = sorted(top_indices)
+    return "\n\n".join(chunks[i] for i in top_indices_sorted)
+
+
 def get_gpt_response(
         client: openai.OpenAI,
         question: str,
         card_context: Optional[str] = None,
         format_type: str = "Any Format",
-        response_style: str = "Judge-Level"
+        response_style: str = "Judge-Level",
+        chunks: Optional[list[str]] = None,
+        embeddings: Optional[np.ndarray] = None,
     ) -> str:
     """
-    Get response from GPT-4o for MTG rules questions.
+    Get a response from GPT-4o-mini for an MTG rules question.
 
-    Uses the OpenAI Responses API with web search so it can look up the
-    official MTG Comprehensive Rules at magic.wizards.com/en/rules before
-    answering. Official rules are always consulted first; other sources are
-    only used when the official rules don't cover the question.
+    For Judge-Level responses, relevant rule sections are retrieved from the
+    pre-built RAG knowledge base and injected into the prompt, ensuring the
+    model always cites the current official rules. Other response styles use
+    training data, which is faster and sufficient for common questions.
 
     Args:
-        client: OpenAI client instance
-        question: User's MTG rules question
-        card_context: Optional card text from Scryfall API
-        format_type: MTG format to focus on (Any Format, Standard, Modern, etc.)
-        response_style: Detail level (Extra-Concise, Concise, Detailed, Judge-Level)
+        client: OpenAI client instance.
+        question: User's MTG rules question.
+        card_context: Optional card text from Scryfall API.
+        format_type: MTG format (Any Format, Standard, Modern, etc.)
+        response_style: Detail level (Extra-Concise, Concise, Detailed, Judge-Level).
+        chunks: Pre-built rule chunks from build_embeddings().
+        embeddings: Pre-built embedding matrix from build_embeddings().
 
     Returns:
-        str: GPT-4o response as formatted string
-
-    Raises:
-        Exception: If API call fails (handled with user-friendly error messages)
+        GPT-4o-mini response as a formatted string.
     """
-    format_context = f"Focus on {format_type} format rules and interactions." if format_type != "Any Format" else "Consider all formats when answering."
+    format_context = (
+        f"Focus on {format_type} format rules and interactions."
+        if format_type != "Any Format"
+        else "Consider all formats when answering."
+    )
 
     style_instruction = {
         "Extra-Concise": "Be extremely concise. Answer in one or two sentences unless accuracy requires more. Bullet points are helpful.",
         "Concise": "Keep your answer brief and to the point. Don't include more detail than necessary. Bullet points are helpful.",
         "Detailed": "Provide a thorough explanation with examples.",
-        "Judge-Level": "Give a comprehensive, judge-quality answer with exact rule citations (e.g. CR 702.12b) and step-by-step breakdowns."
+        "Judge-Level": "Give a comprehensive, judge-quality answer with exact rule citations (e.g. CR 702.12b) and step-by-step breakdowns.",
     }.get(response_style, "Provide a detailed explanation.")
+
+    # For Judge-Level, retrieve the most relevant rule sections from the
+    # knowledge base and inject them directly into the prompt.
+    rules_context = ""
+    if response_style == "Judge-Level":
+        if chunks is None or embeddings is None:
+            return (
+                "❌ **Could not load the official MTG Comprehensive Rules.**\n\n"
+                "Please try switching to a different response style (Detailed, Concise, or Extra-Concise), "
+                "which will use the model's training data instead."
+            )
+        relevant = retrieve_relevant_chunks(client, question, chunks, embeddings)
+        rules_context = f"\n\n**Relevant Official MTG Comprehensive Rules:**\n{relevant}"
 
     system_prompt = f"""You are an expert Magic: The Gathering judge assistant.
 
@@ -94,48 +285,42 @@ def get_gpt_response(
 **Response Style:** {style_instruction}
 
 **Rules Priority (strictly follow this order):**
-1. FIRST, search and cite the official Magic: The Gathering Comprehensive Rules at https://magic.wizards.com/en/rules — this is the authoritative source. Reference rule numbers directly (e.g., "CR 116.3c").
+1. FIRST, cite the official Magic: The Gathering Comprehensive Rules provided below — this is the authoritative source. Reference rule numbers directly (e.g., "CR 116.3c").
 2. Only supplement with other sources (community rulings, judge blogs, etc.) if the official rules do not cover the question.
 
 **When answering:**
-1. Search the official Comprehensive Rules first and cite the governing rule number(s)
+1. Cite the governing rule number(s) from the Comprehensive Rules provided
 2. Use precise MTG terminology
 3. Explain the reasoning behind the ruling
 4. If card text is provided, reference it
 5. If the question involves the stack or timing, explain the sequence using priority rules (CR 116)
 6. For complex interactions, break down each step with rule citations
+7. When evaluating tap restrictions (e.g. summoning sickness), carefully identify *whose* ability is being activated. Summoning sickness (CR 302.6) restricts a creature's *own* activated abilities that include {{T}} in their cost — it does NOT prevent a creature from being tapped to pay the cost of another permanent's ability (e.g. Crew, Station, Convoke).
 
 **Format your answers with:**
-- Governing rule number(s) upfront when applicable
-- Step-by-step breakdown for complex interactions
-- A clear ruling summary"""
+- A clear ruling summary upfront
+- Governing rule number(s) after the summary
+- Step-by-step breakdown for complex interactions{rules_context}"""
 
     user_message = "**Question:** " + question
     if card_context:
         user_message += f"\n\n**Relevant card text:**\n{card_context}"
 
-    # Token budget by response style
     max_output_tokens = {
         "Extra-Concise": 300,
         "Concise": 600,
         "Detailed": 1200,
-        "Judge-Level": 2000,
+        "Judge-Level": 4000,
     }.get(response_style, 2000)
 
     try:
-        # Judge-Level uses live web search to fetch the latest official Comprehensive
-        # Rules from magic.wizards.com/en/rules. All other styles use training data,
-        # which is faster, cheaper, and sufficient for common rules questions.
-        tools = [{"type": "web_search_preview"}] if response_style == "Judge-Level" else []
-
         response = client.responses.create(
-            model="gpt-4o",
-            tools=tools,
+            model="gpt-4o-mini",
             instructions=system_prompt,
             input=user_message,
             max_output_tokens=max_output_tokens,
+            temperature=0,
         )
-        # Extract text output from the response
         for block in response.output:
             if block.type == "message":
                 for content in block.content:
@@ -144,8 +329,19 @@ def get_gpt_response(
         return "❌ **No response returned.** Please try again."
     except Exception as e:
         error_msg = str(e)
-        if "insufficient_quota" in error_msg or "429" in error_msg:
-            return "❌ **API Quota Exceeded**\n\nYou've reached your OpenAI API usage limit. Please:\n\n1. **Check your billing** at https://platform.openai.com/account/billing\n2. **Add credits** to your account\n3. **Try again later**"
+        if "429" in error_msg and "rate_limit" in error_msg.lower():
+            return (
+                "❌ **Rate Limit Reached**\n\n"
+                "Too many requests in a short period. Please wait a moment and try again."
+            )
+        elif "insufficient_quota" in error_msg or "429" in error_msg:
+            return (
+                "❌ **API Quota Exceeded**\n\n"
+                "You've reached your OpenAI API usage limit. Please:\n\n"
+                "1. **Check your billing** at https://platform.openai.com/account/billing\n"
+                "2. **Add credits** to your account\n"
+                "3. **Try again later**"
+            )
         elif "invalid_api_key" in error_msg:
             return "❌ **Invalid API Key**\n\nPlease check your OpenAI API key in the .env file."
         else:
@@ -155,61 +351,79 @@ def get_gpt_response(
 def main():
     """Main Streamlit app function."""
 
-    # Initialize OpenAI client
     client = init_openai_client()
 
-    # Header
     st.title("🃏 MTG Rules Assistant")
     st.markdown("Get judge-quality answers to any MTG rules question.")
-    
-    # Sidebar for settings
+
     with st.sidebar:
         st.header("Settings")
 
-        # Format selection
         st.subheader("Format")
         format_type = st.selectbox(
             "Select format for context:",
             ["Any Format", "Standard", "Modern", "Legacy", "Commander", "Limited"]
         )
 
-        # Response style
         st.subheader("Response Style")
         response_style = st.selectbox(
             "How detailed should the response be?",
             ["Extra-Concise", "Concise", "Detailed", "Judge-Level"],
             index=3
         )
-    
-    # Main content area
+
+        # Build the RAG knowledge base on startup with clear step-by-step status.
+        # Both fetch_rules_text and build_embeddings are cached, so after the first
+        # load this completes instantly and the status collapses automatically.
+        st.subheader("Rules Status")
+        chunks, embeddings = None, None
+        with st.status("Loading rules...", expanded=True) as status:
+            st.write("Fetching official rules from magic.wizards.com...")
+            rules_text, rules_info = fetch_rules_text()
+
+            if not rules_text:
+                status.update(label="Failed to load rules", state="error")
+                st.error(f"Error: {rules_info}")
+            else:
+                st.write("Building knowledge base (may take ~30s on first load)...")
+                rules_hash = hashlib.md5(rules_text.encode()).hexdigest()
+                api_key = client.api_key
+                chunks, embeddings = build_embeddings(rules_hash, api_key)
+
+                if chunks is None:
+                    status.update(label="Failed to build knowledge base", state="error")
+                else:
+                    status.update(
+                        label=f"Rules ready ({len(chunks):,} sections indexed)",
+                        state="complete",
+                        expanded=False,
+                    )
+
     col1, col2 = st.columns([2, 1])
-    
+
     with col1:
-        # Question input — pre-populated when an example button is clicked
         question = st.text_area(
             "Enter your MTG rules question:",
             value=st.session_state.pop("example_question", ""),
             placeholder="e.g., How does indestructible interact with -1/-1 counters?",
             height=120
         )
-        
-        # Submit button
+
         if st.button("🔍 Get Answer", type="primary", use_container_width=True):
             if question.strip():
                 with st.spinner("Looking up the rules..."):
                     card_context = None
-
-                    # Get GPT response with settings
-                    response = get_gpt_response(client, question, card_context, format_type, response_style)
-
-                    # Display response
+                    response = get_gpt_response(
+                        client, question, card_context,
+                        format_type, response_style,
+                        chunks, embeddings,
+                    )
                     st.subheader("Answer")
                     st.markdown(response)
             else:
                 st.warning("Please enter a question.")
-    
+
     with col2:
-        # Example questions
         st.subheader("Examples")
         examples = [
             "How does indestructible interact with -1/-1 counters?",
@@ -221,15 +435,15 @@ def main():
             "How does the stack work with multiple spells?",
             "What happens if a creature loses all abilities?"
         ]
-        
+
         for example in examples:
             if st.button(example, key=example, use_container_width=True):
                 st.session_state.example_question = example
                 st.rerun()
-    
-    # Footer
+
     st.markdown("---")
     st.caption("⚖️ This assistant provides guidance but is not a substitute for official MTG rules or judge rulings.")
 
+
 if __name__ == "__main__":
-    main() 
+    main()

--- a/app.py
+++ b/app.py
@@ -169,6 +169,11 @@ def build_embeddings(rules_hash: str, api_key: str) -> tuple[list[str], np.ndarr
     chunks = build_rule_chunks(rules_text)
     client = openai.OpenAI(api_key=api_key)
 
+    # text-embedding-3-small allows 8191 tokens per item (~4 chars/token → ~32 000 chars).
+    # Truncate long chunks so the API never rejects the request.
+    MAX_CHUNK_CHARS = 30_000
+    chunks = [c[:MAX_CHUNK_CHARS] for c in chunks]
+
     all_embeddings = []
     batch_size = 500
     for i in range(0, len(chunks), batch_size):

--- a/app.py
+++ b/app.py
@@ -8,8 +8,6 @@ Features:
 - GPT-4o powered MTG rules assistance
 - Format-specific responses (Standard, Modern, Legacy, Commander, Limited)
 - Adjustable response detail levels
-- Password protection for controlled access
-- Card name detection (future: Scryfall integration)
 - Mobile-optimized interface
 
 Author: Tyson Clegg
@@ -20,7 +18,6 @@ import streamlit as st
 import openai
 import os
 from typing import Optional
-import re
 
 # Page configuration
 st.set_page_config(
@@ -29,292 +26,169 @@ st.set_page_config(
     layout="wide"
 )
 
-# Initialize OpenAI client
+# Initialize OpenAI client (cached so it's only created once per session)
+@st.cache_resource
 def init_openai_client():
     """
     Initialize OpenAI client with API key from environment variables or Streamlit secrets.
-    
-    This function handles both local development (using .env file) and deployment
-    (using Streamlit secrets). It validates the API key format and provides
-    helpful error messages if the key is missing or invalid.
-    
-    Returns:
-        openai.OpenAI: Configured OpenAI client instance
-        
-    Raises:
-        st.stop(): If API key is missing or invalid
+    Cached with st.cache_resource so the client is reused across reruns.
     """
-    # Try to get API key from Streamlit secrets first (for deployment)
     try:
         api_key = st.secrets.get("OPENAI_API_KEY")
-    except:
+    except Exception:
         api_key = None
-    
-    # Fall back to environment variable (for local development)
+
     if not api_key:
         api_key = os.getenv("OPENAI_API_KEY")
-    
+
     if not api_key:
         st.error("❌ OPENAI_API_KEY not found. Please set it in your environment or Streamlit secrets.")
         st.stop()
-    
-    # Validate API key format (OpenAI keys start with 'sk-' or 'sk-svcacct-')
-    if api_key and (api_key.startswith("sk-") or api_key.startswith("sk-svcacct-")):
+
+    if api_key.startswith("sk-"):
         return openai.OpenAI(api_key=api_key)
     else:
-        st.error(f"❌ Invalid API key format. Got: {api_key[:20] if api_key else 'None'}...")
+        st.error("❌ Invalid API key format. Expected an OpenAI key starting with 'sk-'.")
         st.stop()
 
 def get_gpt_response(
-        client: openai.OpenAI, 
-        question: str, 
-        card_context: Optional[str] = None, 
-        format_type: str = "Any Format", 
-        response_style: str = "Detailed"
+        client: openai.OpenAI,
+        question: str,
+        card_context: Optional[str] = None,
+        format_type: str = "Any Format",
+        response_style: str = "Judge-Level"
     ) -> str:
     """
     Get response from GPT-4o for MTG rules questions.
-    
-    This function constructs a comprehensive prompt for GPT-4o that includes:
-    - MTG-specific system instructions
-    - Format context (Standard, Modern, etc.)
-    - Response style preferences
-    - Card context (if available)
-    - MTG rules context for better accuracy
-    
+
+    Uses the OpenAI Responses API with web search so it can look up the
+    official MTG Comprehensive Rules at magic.wizards.com/en/rules before
+    answering. Official rules are always consulted first; other sources are
+    only used when the official rules don't cover the question.
+
     Args:
         client: OpenAI client instance
         question: User's MTG rules question
         card_context: Optional card text from Scryfall API
         format_type: MTG format to focus on (Any Format, Standard, Modern, etc.)
         response_style: Detail level (Extra-Concise, Concise, Detailed, Judge-Level)
-    
+
     Returns:
         str: GPT-4o response as formatted string
-        
+
     Raises:
         Exception: If API call fails (handled with user-friendly error messages)
     """
-    # Build the system prompt with settings
     format_context = f"Focus on {format_type} format rules and interactions." if format_type != "Any Format" else "Consider all formats when answering."
-    
-    # Define response style instructions for different detail levels
+
     style_instruction = {
-        "Extra-Concise": "Be extremely concise. Unless absolutely necessary to answer the question accurately, answer in one or two sentences. Bullet points are helpful.",
+        "Extra-Concise": "Be extremely concise. Answer in one or two sentences unless accuracy requires more. Bullet points are helpful.",
         "Concise": "Keep your answer brief and to the point. Don't include more detail than necessary. Bullet points are helpful.",
         "Detailed": "Provide a thorough explanation with examples.",
-        "Judge-Level": "Give a comprehensive answer with rule citations and step-by-step breakdowns."
+        "Judge-Level": "Give a comprehensive, judge-quality answer with exact rule citations (e.g. CR 702.12b) and step-by-step breakdowns."
     }.get(response_style, "Provide a detailed explanation.")
-    
-    system_prompt = f"""You are an expert Magic: The Gathering judge assistant with deep knowledge of MTG rules, card interactions, and tournament rulings. 
+
+    system_prompt = f"""You are an expert Magic: The Gathering judge assistant.
 
 **Format Context:** {format_context}
 **Response Style:** {style_instruction}
 
-**Your expertise includes:**
-- Comprehensive understanding of MTG Comprehensive Rules
-- Knowledge of card interactions and edge cases
-- Familiarity with tournament rulings and judge decisions
-- Understanding of different formats (Standard, Modern, Legacy, Commander, etc.)
+**Rules Priority (strictly follow this order):**
+1. FIRST, search and cite the official Magic: The Gathering Comprehensive Rules at https://magic.wizards.com/en/rules — this is the authoritative source. Reference rule numbers directly (e.g., "CR 116.3c").
+2. Only supplement with other sources (community rulings, judge blogs, etc.) if the official rules do not cover the question.
 
 **When answering:**
-1. Use precise MTG terminology and rule citations
-2. Explain the reasoning behind your answer
-3. Reference specific rules when possible (e.g., "Rule 702.12b states...")
-4. If card text is provided, reference it in your explanation
-5. Be concise but thorough
-6. Use a friendly, helpful tone
-7. If the question involves timing or the stack, explain the sequence clearly
-8. For complex interactions, break down the steps
+1. Search the official Comprehensive Rules first and cite the governing rule number(s)
+2. Use precise MTG terminology
+3. Explain the reasoning behind the ruling
+4. If card text is provided, reference it
+5. If the question involves the stack or timing, explain the sequence using priority rules (CR 116)
+6. For complex interactions, break down each step with rule citations
 
 **Format your answers with:**
-- Clear explanations
-- Rule citations when relevant
-- Step-by-step breakdowns for complex interactions
-- Examples when helpful"""
+- Governing rule number(s) upfront when applicable
+- Step-by-step breakdown for complex interactions
+- A clear ruling summary"""
 
-    # Build the user message with MTG context
-    user_message = question
-    
-    # Core MTG rules context to help the AI provide accurate responses
-    mtg_context = """
-**Key MTG Concepts to Consider:**
-- State-based actions happen before any player gets priority
-- The stack resolves last-in, first-out (LIFO)
-- Protection prevents damage, enchanting, blocking, and targeting
-- Indestructible prevents destruction but not other ways of leaving the battlefield
-- Replacement effects can modify how events occur
-- Triggered abilities use "when," "whenever," or "at"
-- Activated abilities have costs and effects separated by colons
-"""
-    
-    # Construct the complete user message with context and question
-    user_message = mtg_context + "\n\n**Question:** " + question
-    
-    # Add card context if available (for future Scryfall integration)
+    user_message = "**Question:** " + question
     if card_context:
         user_message += f"\n\n**Relevant card text:**\n{card_context}"
 
+    # Token budget by response style
+    max_output_tokens = {
+        "Extra-Concise": 300,
+        "Concise": 600,
+        "Detailed": 1200,
+        "Judge-Level": 2000,
+    }.get(response_style, 2000)
+
     try:
-        # Dynamically adjust OpenAI parameters based on response style
-        # This optimizes cost and response quality for different detail levels
-        if response_style == "Extra-Concise":
-            max_tokens = 300  # Very short responses
-            temperature = 0.1  # Very consistent
-        elif response_style == "Concise":
-            max_tokens = 600  # Brief but complete
-            temperature = 0.2  # Consistent with some variety
-        elif response_style == "Detailed":
-            max_tokens = 1200  # Thorough explanations
-            temperature = 0.3  # Balanced consistency and creativity
-        else:  # Judge-Level
-            max_tokens = 2000  # Comprehensive with citations
-            temperature = 0.2  # Consistent for accuracy
-        
-        # Make the API call to GPT-4o
-        response = client.chat.completions.create(
+        # Judge-Level uses live web search to fetch the latest official Comprehensive
+        # Rules from magic.wizards.com/en/rules. All other styles use training data,
+        # which is faster, cheaper, and sufficient for common rules questions.
+        tools = [{"type": "web_search_preview"}] if response_style == "Judge-Level" else []
+
+        response = client.responses.create(
             model="gpt-4o",
-            messages=[
-                {"role": "system", "content": system_prompt},
-                {"role": "user", "content": user_message}
-            ],
-            max_tokens=max_tokens,
-            temperature=temperature
+            tools=tools,
+            instructions=system_prompt,
+            input=user_message,
+            max_output_tokens=max_output_tokens,
         )
-        return response.choices[0].message.content
+        # Extract text output from the response
+        for block in response.output:
+            if block.type == "message":
+                for content in block.content:
+                    if content.type == "output_text":
+                        return content.text
+        return "❌ **No response returned.** Please try again."
     except Exception as e:
         error_msg = str(e)
-        
-        # Handle specific OpenAI API errors with user-friendly messages
         if "insufficient_quota" in error_msg or "429" in error_msg:
-            return "❌ **API Quota Exceeded**\n\nYou've reached your OpenAI API usage limit. Please:\n\n1. **Check your billing** at https://platform.openai.com/account/billing\n2. **Add credits** to your account\n3. **Try again later**\n\nThis is a billing issue, not a problem with the app."
+            return "❌ **API Quota Exceeded**\n\nYou've reached your OpenAI API usage limit. Please:\n\n1. **Check your billing** at https://platform.openai.com/account/billing\n2. **Add credits** to your account\n3. **Try again later**"
         elif "invalid_api_key" in error_msg:
             return "❌ **Invalid API Key**\n\nPlease check your OpenAI API key in the .env file."
         else:
             return f"❌ **Error getting response:** {error_msg}"
 
-def extract_card_names(text: str) -> list[str]:
-    """
-    Extract potential card names from text using simple heuristics.
-    
-    This function uses regex patterns to identify potential MTG card names
-    in user questions. It's designed to work with the Scryfall API for
-    future card lookup functionality.
-    
-    Note: This is a basic implementation. For production use, consider:
-    - Using a proper MTG card database
-    - Implementing fuzzy matching
-    - Adding context-aware detection
-    
-    Args:
-        text: The input text to search for card names
-        
-    Returns:
-        list[str]: List of potential card names (limited to 5)
-    """
-    # Regex pattern to find capitalized words/phrases that might be card names
-    # Matches: "Lightning Bolt", "Black Lotus", "Force of Will", etc.
-    words = re.findall(r'\b[A-Z][a-zA-Z\s\-\']+\b', text)
-    
-    # Filter out common words and short names to reduce false positives
-    common_words = ['the', 'and', 'or', 'but', 'for', 'with', 'from', 'into', 
-                   'during', 'including', 'until', 'against', 'among', 
-                   'throughout', 'despite', 'towards', 'upon']
-    
-    filtered = [word.strip() for word in words 
-               if len(word.strip()) > 2 and word.strip().lower() not in common_words]
-    
-    return filtered[:5]  # Limit results to prevent API spam
-
-# AUTHENTICATION
-
-def check_password():
-    """
-    Simple password protection for controlled access to the app.
-    
-    This function implements basic password authentication using Streamlit's
-    session state and secrets management. The password is checked against
-    Streamlit secrets (for deployment) or a default value (for development).
-    
-    Security features:
-    - Password input is hidden (type="password")
-    - Password is deleted from session state after verification
-    - Uses Streamlit secrets for secure storage in production
-    
-    Returns:
-        bool: True if password is correct, False otherwise
-    """
-    def password_entered():
-        """Check if the entered password matches the stored secret."""
-        # Get password from Streamlit secrets (deployment) or use default (development)
-        correct_password = st.secrets.get("password", "mtg2024")
-        
-        if st.session_state["password"] == correct_password:
-            st.session_state["password_correct"] = True
-            del st.session_state["password"]  # Security: Don't store password in session
-        else:
-            st.session_state["password_correct"] = False
-
-    # Show password input on first visit
-    if "password_correct" not in st.session_state:
-        st.text_input("Password", type="password", on_change=password_entered, key="password")
-        return False
-    elif not st.session_state["password_correct"]:
-        # Show password input with error message for incorrect attempts
-        st.text_input("Password", type="password", on_change=password_entered, key="password")
-        st.error("😕 User not known or password incorrect")
-        return False
-    else:
-        # Password is correct, allow access
-        return True
 
 def main():
     """Main Streamlit app function."""
-    
-    # Check authentication first
-    # if not check_password():
-    #     st.stop()
-    
+
     # Initialize OpenAI client
     client = init_openai_client()
-    
+
     # Header
     st.title("🃏 MTG Rules Assistant")
-    st.markdown("Ask any Magic: The Gathering rules question and get a judge-like response powered by GPT-4o!")
+    st.markdown("Get judge-quality answers to any MTG rules question.")
     
     # Sidebar for settings
     with st.sidebar:
-        st.header("⚙️ Settings")
-        st.info("This assistant uses GPT-4o to provide accurate MTG rules guidance.")
-        
+        st.header("Settings")
+
         # Format selection
-        st.subheader("🎮 Format")
+        st.subheader("Format")
         format_type = st.selectbox(
             "Select format for context:",
             ["Any Format", "Standard", "Modern", "Legacy", "Commander", "Limited"]
         )
-        
+
         # Response style
-        st.subheader("📝 Response Style")
+        st.subheader("Response Style")
         response_style = st.selectbox(
             "How detailed should the response be?",
-            ["Extra-Concise", "Concise", "Detailed", "Judge-Level"]
+            ["Extra-Concise", "Concise", "Detailed", "Judge-Level"],
+            index=3
         )
-        
-        st.markdown("---")
-        st.markdown("**Future Features:**")
-        st.markdown("- Card text lookup via Scryfall")
-        st.markdown("- Rule citation links")
-        st.markdown("- Question history")
     
     # Main content area
     col1, col2 = st.columns([2, 1])
     
     with col1:
-        # Question input
-        st.subheader("📝 Ask Your Question")
+        # Question input — pre-populated when an example button is clicked
         question = st.text_area(
             "Enter your MTG rules question:",
+            value=st.session_state.pop("example_question", ""),
             placeholder="e.g., How does indestructible interact with -1/-1 counters?",
             height=120
         )
@@ -322,31 +196,21 @@ def main():
         # Submit button
         if st.button("🔍 Get Answer", type="primary", use_container_width=True):
             if question.strip():
-                with st.spinner("🤔 Thinking like a judge..."):
-                    # Reinitialize client for each request to avoid caching issues
-                    fresh_client = init_openai_client()
-                    
-                    # For now, we'll skip card lookup but leave the structure
+                with st.spinner("Looking up the rules..."):
                     card_context = None
-                    
+
                     # Get GPT response with settings
-                    response = get_gpt_response(fresh_client, question, card_context, format_type, response_style)
-                    
+                    response = get_gpt_response(client, question, card_context, format_type, response_style)
+
                     # Display response
-                    st.subheader("📋 Answer")
+                    st.subheader("Answer")
                     st.markdown(response)
-                    
-                    # Optional: Show detected card names (for future enhancement)
-                    detected_cards = extract_card_names(question)
-                    if detected_cards:
-                        st.info(f"💡 Detected potential card names: {', '.join(detected_cards)}")
-                        st.caption("Card lookup feature coming soon!")
             else:
                 st.warning("Please enter a question.")
     
     with col2:
         # Example questions
-        st.subheader("💡 Example Questions")
+        st.subheader("Examples")
         examples = [
             "How does indestructible interact with -1/-1 counters?",
             "Can I counter a spell that can't be countered?",
@@ -362,11 +226,6 @@ def main():
             if st.button(example, key=example, use_container_width=True):
                 st.session_state.example_question = example
                 st.rerun()
-        
-        # Handle example selection
-        if 'example_question' in st.session_state:
-            question = st.session_state.example_question
-            del st.session_state.example_question
     
     # Footer
     st.markdown("---")

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ openai
 streamlit
 scrython
 python-dotenv
+requests
+numpy


### PR DESCRIPTION
## Summary
- Makes the summoning sickness rule in the system prompt more explicit with a concrete example
- Clarifies that CR 302.6 only restricts a creature's own {T} abilities — not being tapped as a cost for another card's ability (Station, Crew, Convoke)

## Test plan
- [ ] Ask "Can I station a ship with a creature that has summoning sickness?" and verify the answer is correct (yes, it can be tapped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)